### PR TITLE
fix: update error handling conditional for Windows compatibility and …

### DIFF
--- a/src/error.cpp
+++ b/src/error.cpp
@@ -65,7 +65,7 @@ namespace sorth::internal
 
 
 
-    #if defined(_WIN64)
+    #if defined(_WIN64) || defined(IS_WINDOWS)
 
 
         [[noreturn]]

--- a/src/error.h
+++ b/src/error.h
@@ -31,21 +31,18 @@ namespace sorth
                             const std::string& message);
 
 
-        #if defined(_WIN64)
 
+    #if defined(_WIN64) || defined(IS_WINDOWS)
+        [[noreturn]]
+        void throw_windows_error(const InterpreterPtr& interpreter,
+                    const std::string& message,
+                    DWORD code);
 
-            [[noreturn]]
-            void throw_windows_error(const InterpreterPtr& interpreter,
-                                    const std::string& message,
-                                    DWORD code);
-
-            void throw_windows_error_if(bool condition,
-                                        const InterpreterPtr& interpreter,
-                                        const std::string& message,
-                                        DWORD code);
-
-
-        #endif
+        void throw_windows_error_if(bool condition,
+                        const InterpreterPtr& interpreter,
+                        const std::string& message,
+                        DWORD code);
+    #endif
 
 
     }

--- a/src/run-time/built-ins/ffi-words.cpp
+++ b/src/run-time/built-ins/ffi-words.cpp
@@ -1,5 +1,6 @@
 
 #include "sorth.h"
+#include "error.h"
 
 #ifdef IS_WINDOWS
 

--- a/src/run-time/built-ins/io-words-windows.cpp
+++ b/src/run-time/built-ins/io-words-windows.cpp
@@ -1,5 +1,6 @@
 
 #include "sorth.h"
+#include "error.h"
 
 
 #if defined (IS_WINDOWS)

--- a/src/run-time/built-ins/terminal-words.cpp
+++ b/src/run-time/built-ins/terminal-words.cpp
@@ -22,8 +22,7 @@ namespace sorth
     using namespace internal;
 
 
-    namespace
-    {
+    // Removed unnamed namespace to give external linkage to terminal word functions
 
         #if defined(__APPLE__) || defined(__linux__)
 
@@ -278,42 +277,43 @@ namespace sorth
         }
 
 
-    }
 
 
-    SORTH_API void register_terminal_words(InterpreterPtr& interpreter)
+
+
+    void register_terminal_words(InterpreterPtr& interpreter)
     {
-        #if defined(_WIN64)
-
-            init_win_console();
-
-        #endif
-
-
+#if defined(__APPLE__) || defined(__linux__)
         ADD_NATIVE_WORD(interpreter, "term.raw_mode", word_term_raw_mode,
                         "Enter or leave the terminal's 'raw' mode.",
                         "bool -- ");
-
         ADD_NATIVE_WORD(interpreter, "term.size@", word_term_size,
                         "Return the number or characters in the rows and columns.",
                         " -- columns rows");
-
         ADD_NATIVE_WORD(interpreter, "term.key", word_term_key,
                         "Read a keypress from the terminal.",
                         " -- character");
-
+#elif defined(_WIN64)
+        init_win_console();
+        ADD_NATIVE_WORD(interpreter, "term.raw_mode", word_term_raw_mode,
+                        "Enter or leave the terminal's 'raw' mode.",
+                        "bool -- ");
+        ADD_NATIVE_WORD(interpreter, "term.size@", word_term_size,
+                        "Return the number or characters in the rows and columns.",
+                        " -- columns rows");
+        ADD_NATIVE_WORD(interpreter, "term.key", word_term_key,
+                        "Read a keypress from the terminal.",
+                        " -- character");
+#endif
         ADD_NATIVE_WORD(interpreter, "term.flush", word_term_flush,
                         "Flush the terminals buffers.",
                         " -- ");
-
         ADD_NATIVE_WORD(interpreter, "term.readline", word_term_read_line,
                         "Read a line of text from the terminal.",
                         " -- string");
-
         ADD_NATIVE_WORD(interpreter, "term.!", word_term_write,
                         "Write a value to the terminal.",
                         "value -- ");
-
         ADD_NATIVE_WORD(interpreter, "term.is_printable?", word_term_is_printable,
                         "Is the given character printable?",
                         "character -- bool");


### PR DESCRIPTION
…refactor terminal words registration in C++ source files

```
 task sorth:build
task: [sorth:build] cmd /c mkdir -p build || exit 0
A subdirectory or file -p already exists.
Error occurred while processing: -p.
A subdirectory or file build already exists.
Error occurred while processing: build.
task: [sorth:build] cmake -DCMAKE_TOOLCHAIN_FILE=..\\vcpkg\\scripts\\buildsystems\\vcpkg.cmake --preset=default -G Ninja
Preset environment variables:

  VCPKG_ROOT="C:/w/f/rsorth/sorth/../vcpkg/"

-- Running vcpkg install
Detecting compiler hash for triplet x64-windows...
Compiler found: C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.44.35207/bin/Hostx64/x64/cl.exe
Detecting compiler hash for triplet x86-windows...
Compiler found: C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.44.35207/bin/Hostx64/x86/cl.exe
The following packages are already installed:
    libffi:x86-windows@3.4.6 -- git+https://github.com/microsoft/vcpkg@0ad381012102db5da196161ba7fc0a03a4dcb982
  * vcpkg-cmake:x64-windows@2024-04-23 -- git+https://github.com/microsoft/vcpkg@e74aa1e8f93278a8e71372f1fa08c3df420eb840
  * vcpkg-cmake-get-vars:x64-windows@2024-09-22 -- git+https://github.com/microsoft/vcpkg@f23148add155147f3d95ae622d3b0031beb25acf
libffi can be imported via CMake FindPkgConfig module:

    find_package(PkgConfig)
    pkg_check_modules(LIBFFI REQUIRED IMPORTED_TARGET libffi)
    target_link_libraries(main PRIVATE PkgConfig::LIBFFI)

vcpkg provides proprietary CMake targets:

    find_package(unofficial-libffi CONFIG REQUIRED)
    target_link_libraries(main PRIVATE unofficial::libffi::libffi)

All requested installations completed successfully in: 528 us
-- Running vcpkg install - done
-- Checking for LLVM...
--   LLVM not found, JIT functionality will be disabled.
-- Target architecture is not ARM.
-- Configuring done (4.5s)
-- Generating done (0.0s)
CMake Warning:
  Manually-specified variables were not used by the project:

    CMAKE_TOOLCHAIN_FILE


-- Build files have been written to: C:/w/f/rsorth/sorth/build
task: [sorth:build] cmd /c cd build && ninja -C build
ninja: Entering directory `build'
[6/42] Building CXX object CMakeFiles\sorth-interpreter.dir\src\run-time\built-ins\terminal-words.cpp.obj
FAILED: CMakeFiles/sorth-interpreter.dir/src/run-time/built-ins/terminal-words.cpp.obj
C:\PROGRA~1\MICROS~1\2022\COMMUN~1\VC\Tools\MSVC\1444~1.352\bin\Hostx86\x86\cl.exe  /nologo /TP -DSORTH_EXPORT=1 -DSORTH_LLVM_FOUND=0 -DSORTH_VERSION=\"dev-f0e2f4e0-2025.01.17\" -Dsorth_interpreter_EXPORTS -IC:\w\f\rsorth\sorth\src -external:IC:\w\f\rsorth\sorth\build\vcpkg_installed\x86-windows\include -external:W0 /DWIN32 /D_WINDOWS /GR /EHsc /Zi /Ob0 /Od /RTC1 -std:c++20 -MDd "-DSORTH_COMPILER=\"cl 19.44.35207.1\"" /YuC:/w/f/rsorth/sorth/build/CMakeFiles/sorth-interpreter.dir/cmake_pch.hxx /FpC:/w/f/rsorth/sorth/build/CMakeFiles/sorth-interpreter.dir/./cmake_pch.cxx.pch /FIC:/w/f/rsorth/sorth/build/CMakeFiles/sorth-interpreter.dir/cmake_pch.hxx /showIncludes /FoCMakeFiles\sorth-interpreter.dir\src\run-time\built-ins\terminal-words.cpp.obj /FdCMakeFiles\sorth-interpreter.dir\ /FS -c C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(293): error C2065: 'word_term_raw_mode': undeclared identifier
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(293): error C2665: 'sorth::Interpreter::add_word': no overloaded function could convert all the argument types
C:\w\f\rsorth\sorth\src\run-time/interpreter/interpreter.h(197): note: could be 'void sorth::Interpreter::add_word(const std::string &,sorth::internal::WordFunction,const std::filesystem::path &,size_t,size_t,sorth::internal::ExecutionContext,const std::string &,const std::string &)'
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(293): note: 'void sorth::Interpreter::add_word(const std::string &,sorth::internal::WordFunction,const std::filesystem::path &,size_t,size_t,sorth::internal::ExecutionContext,const std::string &,const std::string &)': cannot convert argument 2 from 'const char [62]' to 'sorth::internal::WordFunction'
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(293): note: 'sorth::internal::WordFunction::WordFunction': no overloaded function could convert all the argument types
C:\w\f\rsorth\sorth\src\run-time/data-structures/word-function.h(25): note: could be 'sorth::internal::WordFunction::WordFunction(sorth::internal::WordFunction &&)'      
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(293): note: 'sorth::internal::WordFunction::WordFunction(sorth::internal::WordFunction &&)': cannot convert argument 1 from 'const char [62]' to 'sorth::internal::WordFunction &&'
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(293): note: Reason: cannot convert from 'const char [62]' to 'sorth::internal::WordFunction'
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(293): note: Conversion requires a second user-defined-conversion operator or constructor
C:\w\f\rsorth\sorth\src\run-time/data-structures/word-function.h(24): note: or       'sorth::internal::WordFunction::WordFunction(const sorth::internal::WordFunction &)' 
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(293): note: 'sorth::internal::WordFunction::WordFunction(const sorth::internal::WordFunction &)': cannot convert argument 1 from 'const char [62]' to 'const sorth::internal::WordFunction &'
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(293): note: Reason: cannot convert from 'const char [62]' to 'const sorth::internal::WordFunction'
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(293): note: Conversion requires a second user-defined-conversion operator or constructor
C:\w\f\rsorth\sorth\src\run-time/data-structures/word-function.h(23): note: or       'sorth::internal::WordFunction::WordFunction(const sorth::internal::WordFunction::Handler &)'
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(293): note: 'sorth::internal::WordFunction::WordFunction(const sorth::internal::WordFunction::Handler &)': cannot convert argument 1 from 'const char [62]' to 'const sorth::internal::WordFunction::Handler &'
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(293): note: Reason: cannot convert from 'const char [62]' to 'const sorth::internal::WordFunction::Handler' 
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(293): note: Conversion requires a second user-defined-conversion operator or constructor
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(293): note: while trying to match the argument list '(const char [62])'
C:\w\f\rsorth\sorth\src\run-time/interpreter/interpreter.h(187): note: or       'void sorth::Interpreter::add_word(const std::string &,sorth::internal::WordFunction,const sorth::internal::Location &,sorth::internal::ExecutionContext,sorth::internal::WordVisibility,sorth::internal::WordType,const std::string &,const std::string &)'        
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(293): note: 'void sorth::Interpreter::add_word(const std::string &,sorth::internal::WordFunction,const sorth::internal::Location &,sorth::internal::ExecutionContext,sorth::internal::WordVisibility,sorth::internal::WordType,const std::string &,const std::string &)': cannot convert argument 2 from 'const char [62]' to 'sorth::internal::WordFunction'
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(293): note: 'sorth::internal::WordFunction::WordFunction': no overloaded function could convert all the argument types
C:\w\f\rsorth\sorth\src\run-time/data-structures/word-function.h(25): note: could be 'sorth::internal::WordFunction::WordFunction(sorth::internal::WordFunction &&)'      
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(293): note: 'sorth::internal::WordFunction::WordFunction(sorth::internal::WordFunction &&)': cannot convert argument 1 from 'const char [62]' to 'sorth::internal::WordFunction &&'
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(293): note: Reason: cannot convert from 'const char [62]' to 'sorth::internal::WordFunction'
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(293): note: Conversion requires a second user-defined-conversion operator or constructor
C:\w\f\rsorth\sorth\src\run-time/data-structures/word-function.h(24): note: or       'sorth::internal::WordFunction::WordFunction(const sorth::internal::WordFunction &)' 
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(293): note: 'sorth::internal::WordFunction::WordFunction(const sorth::internal::WordFunction &)': cannot convert argument 1 from 'const char [62]' to 'const sorth::internal::WordFunction &'
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(293): note: Reason: cannot convert from 'const char [62]' to 'const sorth::internal::WordFunction'
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(293): note: Conversion requires a second user-defined-conversion operator or constructor
C:\w\f\rsorth\sorth\src\run-time/data-structures/word-function.h(23): note: or       'sorth::internal::WordFunction::WordFunction(const sorth::internal::WordFunction::Handler &)'
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(293): note: 'sorth::internal::WordFunction::WordFunction(const sorth::internal::WordFunction::Handler &)': cannot convert argument 1 from 'const char [62]' to 'const sorth::internal::WordFunction::Handler &'
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(293): note: Reason: cannot convert from 'const char [62]' to 'const sorth::internal::WordFunction::Handler' 
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(293): note: Conversion requires a second user-defined-conversion operator or constructor
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(293): note: while trying to match the argument list '(const char [62])'
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(293): note: while trying to match the argument list '(const char [14], const char [62], int, int, sorth::internal::ExecutionContext, const char [42], const char [9])'
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(297): error C2065: 'word_term_size': undeclared identifier
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(297): error C2665: 'sorth::Interpreter::add_word': no overloaded function could convert all the argument types
C:\w\f\rsorth\sorth\src\run-time/interpreter/interpreter.h(197): note: could be 'void sorth::Interpreter::add_word(const std::string &,sorth::internal::WordFunction,const std::filesystem::path &,size_t,size_t,sorth::internal::ExecutionContext,const std::string &,const std::string &)'
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(297): note: 'void sorth::Interpreter::add_word(const std::string &,sorth::internal::WordFunction,const std::filesystem::path &,size_t,size_t,sorth::internal::ExecutionContext,const std::string &,const std::string &)': cannot convert argument 2 from 'const char [62]' to 'sorth::internal::WordFunction'
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(297): note: 'sorth::internal::WordFunction::WordFunction': no overloaded function could convert all the argument types
C:\w\f\rsorth\sorth\src\run-time/data-structures/word-function.h(25): note: could be 'sorth::internal::WordFunction::WordFunction(sorth::internal::WordFunction &&)'      
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(297): note: 'sorth::internal::WordFunction::WordFunction(sorth::internal::WordFunction &&)': cannot convert argument 1 from 'const char [62]' to 'sorth::internal::WordFunction &&'
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(297): note: Reason: cannot convert from 'const char [62]' to 'sorth::internal::WordFunction'
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(297): note: Conversion requires a second user-defined-conversion operator or constructor
C:\w\f\rsorth\sorth\src\run-time/data-structures/word-function.h(24): note: or       'sorth::internal::WordFunction::WordFunction(const sorth::internal::WordFunction &)' 
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(297): note: 'sorth::internal::WordFunction::WordFunction(const sorth::internal::WordFunction &)': cannot convert argument 1 from 'const char [62]' to 'const sorth::internal::WordFunction &'
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(297): note: Reason: cannot convert from 'const char [62]' to 'const sorth::internal::WordFunction'
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(297): note: Conversion requires a second user-defined-conversion operator or constructor
C:\w\f\rsorth\sorth\src\run-time/data-structures/word-function.h(23): note: or       'sorth::internal::WordFunction::WordFunction(const sorth::internal::WordFunction::Handler &)'
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(297): note: 'sorth::internal::WordFunction::WordFunction(const sorth::internal::WordFunction::Handler &)': cannot convert argument 1 from 'const char [62]' to 'const sorth::internal::WordFunction::Handler &'
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(297): note: Reason: cannot convert from 'const char [62]' to 'const sorth::internal::WordFunction::Handler' 
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(297): note: Conversion requires a second user-defined-conversion operator or constructor
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(297): note: while trying to match the argument list '(const char [62])'
C:\w\f\rsorth\sorth\src\run-time/interpreter/interpreter.h(187): note: or       'void sorth::Interpreter::add_word(const std::string &,sorth::internal::WordFunction,const sorth::internal::Location &,sorth::internal::ExecutionContext,sorth::internal::WordVisibility,sorth::internal::WordType,const std::string &,const std::string &)'        
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(297): note: 'void sorth::Interpreter::add_word(const std::string &,sorth::internal::WordFunction,const sorth::internal::Location &,sorth::internal::ExecutionContext,sorth::internal::WordVisibility,sorth::internal::WordType,const std::string &,const std::string &)': cannot convert argument 2 from 'const char [62]' to 'sorth::internal::WordFunction'
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(297): note: 'sorth::internal::WordFunction::WordFunction': no overloaded function could convert all the argument types
C:\w\f\rsorth\sorth\src\run-time/data-structures/word-function.h(25): note: could be 'sorth::internal::WordFunction::WordFunction(sorth::internal::WordFunction &&)'      
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(297): note: 'sorth::internal::WordFunction::WordFunction(sorth::internal::WordFunction &&)': cannot convert argument 1 from 'const char [62]' to 'sorth::internal::WordFunction &&'
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(297): note: Reason: cannot convert from 'const char [62]' to 'sorth::internal::WordFunction'
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(297): note: Conversion requires a second user-defined-conversion operator or constructor
C:\w\f\rsorth\sorth\src\run-time/data-structures/word-function.h(24): note: or       'sorth::internal::WordFunction::WordFunction(const sorth::internal::WordFunction &)' 
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(297): note: 'sorth::internal::WordFunction::WordFunction(const sorth::internal::WordFunction &)': cannot convert argument 1 from 'const char [62]' to 'const sorth::internal::WordFunction &'
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(297): note: Reason: cannot convert from 'const char [62]' to 'const sorth::internal::WordFunction'
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(297): note: Conversion requires a second user-defined-conversion operator or constructor
C:\w\f\rsorth\sorth\src\run-time/data-structures/word-function.h(23): note: or       'sorth::internal::WordFunction::WordFunction(const sorth::internal::WordFunction::Handler &)'
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(297): note: 'sorth::internal::WordFunction::WordFunction(const sorth::internal::WordFunction::Handler &)': cannot convert argument 1 from 'const char [62]' to 'const sorth::internal::WordFunction::Handler &'
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(297): note: Reason: cannot convert from 'const char [62]' to 'const sorth::internal::WordFunction::Handler' 
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(297): note: Conversion requires a second user-defined-conversion operator or constructor
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(297): note: while trying to match the argument list '(const char [62])'
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(297): note: while trying to match the argument list '(const char [11], const char [62], int, int, sorth::internal::ExecutionContext, const char [57], const char [17])'
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(301): error C2065: 'word_term_key': undeclared identifier
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(301): error C2665: 'sorth::Interpreter::add_word': no overloaded function could convert all the argument types
C:\w\f\rsorth\sorth\src\run-time/interpreter/interpreter.h(197): note: could be 'void sorth::Interpreter::add_word(const std::string &,sorth::internal::WordFunction,const std::filesystem::path &,size_t,size_t,sorth::internal::ExecutionContext,const std::string &,const std::string &)'
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(301): note: 'void sorth::Interpreter::add_word(const std::string &,sorth::internal::WordFunction,const std::filesystem::path &,size_t,size_t,sorth::internal::ExecutionContext,const std::string &,const std::string &)': cannot convert argument 2 from 'const char [62]' to 'sorth::internal::WordFunction'
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(301): note: 'sorth::internal::WordFunction::WordFunction': no overloaded function could convert all the argument types
C:\w\f\rsorth\sorth\src\run-time/data-structures/word-function.h(25): note: could be 'sorth::internal::WordFunction::WordFunction(sorth::internal::WordFunction &&)'      
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(301): note: 'sorth::internal::WordFunction::WordFunction(sorth::internal::WordFunction &&)': cannot convert argument 1 from 'const char [62]' to 'sorth::internal::WordFunction &&'
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(301): note: Reason: cannot convert from 'const char [62]' to 'sorth::internal::WordFunction'
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(301): note: Conversion requires a second user-defined-conversion operator or constructor
C:\w\f\rsorth\sorth\src\run-time/data-structures/word-function.h(24): note: or       'sorth::internal::WordFunction::WordFunction(const sorth::internal::WordFunction &)' 
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(301): note: 'sorth::internal::WordFunction::WordFunction(const sorth::internal::WordFunction &)': cannot convert argument 1 from 'const char [62]' to 'const sorth::internal::WordFunction &'
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(301): note: Reason: cannot convert from 'const char [62]' to 'const sorth::internal::WordFunction'
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(301): note: Conversion requires a second user-defined-conversion operator or constructor
C:\w\f\rsorth\sorth\src\run-time/data-structures/word-function.h(23): note: or       'sorth::internal::WordFunction::WordFunction(const sorth::internal::WordFunction::Handler &)'
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(301): note: 'sorth::internal::WordFunction::WordFunction(const sorth::internal::WordFunction::Handler &)': cannot convert argument 1 from 'const char [62]' to 'const sorth::internal::WordFunction::Handler &'
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(301): note: Reason: cannot convert from 'const char [62]' to 'const sorth::internal::WordFunction::Handler' 
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(301): note: Conversion requires a second user-defined-conversion operator or constructor
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(301): note: while trying to match the argument list '(const char [62])'
C:\w\f\rsorth\sorth\src\run-time/interpreter/interpreter.h(187): note: or       'void sorth::Interpreter::add_word(const std::string &,sorth::internal::WordFunction,const sorth::internal::Location &,sorth::internal::ExecutionContext,sorth::internal::WordVisibility,sorth::internal::WordType,const std::string &,const std::string &)'        
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(301): note: 'void sorth::Interpreter::add_word(const std::string &,sorth::internal::WordFunction,const sorth::internal::Location &,sorth::internal::ExecutionContext,sorth::internal::WordVisibility,sorth::internal::WordType,const std::string &,const std::string &)': cannot convert argument 2 from 'const char [62]' to 'sorth::internal::WordFunction'
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(301): note: 'sorth::internal::WordFunction::WordFunction': no overloaded function could convert all the argument types
C:\w\f\rsorth\sorth\src\run-time/data-structures/word-function.h(25): note: could be 'sorth::internal::WordFunction::WordFunction(sorth::internal::WordFunction &&)'      
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(301): note: 'sorth::internal::WordFunction::WordFunction(sorth::internal::WordFunction &&)': cannot convert argument 1 from 'const char [62]' to 'sorth::internal::WordFunction &&'
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(301): note: Reason: cannot convert from 'const char [62]' to 'sorth::internal::WordFunction'
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(301): note: Conversion requires a second user-defined-conversion operator or constructor
C:\w\f\rsorth\sorth\src\run-time/data-structures/word-function.h(24): note: or       'sorth::internal::WordFunction::WordFunction(const sorth::internal::WordFunction &)' 
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(301): note: 'sorth::internal::WordFunction::WordFunction(const sorth::internal::WordFunction &)': cannot convert argument 1 from 'const char [62]' to 'const sorth::internal::WordFunction &'
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(301): note: Reason: cannot convert from 'const char [62]' to 'const sorth::internal::WordFunction'
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(301): note: Conversion requires a second user-defined-conversion operator or constructor
C:\w\f\rsorth\sorth\src\run-time/data-structures/word-function.h(23): note: or       'sorth::internal::WordFunction::WordFunction(const sorth::internal::WordFunction::Handler &)'
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(301): note: 'sorth::internal::WordFunction::WordFunction(const sorth::internal::WordFunction::Handler &)': cannot convert argument 1 from 'const char [62]' to 'const sorth::internal::WordFunction::Handler &'
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(301): note: Reason: cannot convert from 'const char [62]' to 'const sorth::internal::WordFunction::Handler' 
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(301): note: Conversion requires a second user-defined-conversion operator or constructor
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(301): note: while trying to match the argument list '(const char [62])'
C:\w\f\rsorth\sorth\src\run-time\built-ins\terminal-words.cpp(301): note: while trying to match the argument list '(const char [9], const char [62], int, int, sorth::internal::ExecutionContext, const char [35], const char [14])'
[12/42] Building CXX object CMakeFiles\sorth-interpreter.dir\src\run-time\built-ins\io-words-windows.cpp.obj
FAILED: CMakeFiles/sorth-interpreter.dir/src/run-time/built-ins/io-words-windows.cpp.obj
C:\PROGRA~1\MICROS~1\2022\COMMUN~1\VC\Tools\MSVC\1444~1.352\bin\Hostx86\x86\cl.exe  /nologo /TP -DSORTH_EXPORT=1 -DSORTH_LLVM_FOUND=0 -DSORTH_VERSION=\"dev-f0e2f4e0-2025.01.17\" -Dsorth_interpreter_EXPORTS -IC:\w\f\rsorth\sorth\src -external:IC:\w\f\rsorth\sorth\build\vcpkg_installed\x86-windows\include -external:W0 /DWIN32 /D_WINDOWS /GR /EHsc /Zi /Ob0 /Od /RTC1 -std:c++20 -MDd "-DSORTH_COMPILER=\"cl 19.44.35207.1\"" /YuC:/w/f/rsorth/sorth/build/CMakeFiles/sorth-interpreter.dir/cmake_pch.hxx /FpC:/w/f/rsorth/sorth/build/CMakeFiles/sorth-interpreter.dir/./cmake_pch.cxx.pch /FIC:/w/f/rsorth/sorth/build/CMakeFiles/sorth-interpreter.dir/cmake_pch.hxx /showIncludes /FoCMakeFiles\sorth-interpreter.dir\src\run-time\built-ins\io-words-windows.cpp.obj /FdCMakeFiles\sorth-interpreter.dir\ /FS -c C:\w\f\rsorth\sorth\src\run-time\built-ins\io-words-windows.cpp
C:\w\f\rsorth\sorth\src\run-time\built-ins\io-words-windows.cpp(39): error C3861: 'throw_windows_error': identifier not found
C:\w\f\rsorth\sorth\src\run-time\built-ins\io-words-windows.cpp(60): error C3861: 'throw_windows_error': identifier not found
C:\w\f\rsorth\sorth\src\run-time\built-ins\io-words-windows.cpp(89): error C3861: 'throw_windows_error': identifier not found
C:\w\f\rsorth\sorth\src\run-time\built-ins\io-words-windows.cpp(115): error C3861: 'throw_windows_error_if': identifier not found
C:\w\f\rsorth\sorth\src\run-time\built-ins\io-words-windows.cpp(122): error C3861: 'throw_windows_error_if': identifier not found
C:\w\f\rsorth\sorth\src\run-time\built-ins\io-words-windows.cpp(153): error C3861: 'throw_windows_error': identifier not found
C:\w\f\rsorth\sorth\src\run-time\built-ins\io-words-windows.cpp(168): error C3861: 'throw_windows_error': identifier not found
C:\w\f\rsorth\sorth\src\run-time\built-ins\io-words-windows.cpp(196): error C3861: 'throw_windows_error': identifier not found
C:\w\f\rsorth\sorth\src\run-time\built-ins\io-words-windows.cpp(215): error C3861: 'throw_windows_error': identifier not found
C:\w\f\rsorth\sorth\src\run-time\built-ins\io-words-windows.cpp(277): error C3861: 'throw_windows_error': identifier not found
C:\w\f\rsorth\sorth\src\run-time\built-ins\io-words-windows.cpp(336): error C3861: 'throw_windows_error': identifier not found
[33/42] Building CXX object CMakeFiles\sorth-interpreter.dir\src\run-time\built-ins\ffi-words.cpp.obj
FAILED: CMakeFiles/sorth-interpreter.dir/src/run-time/built-ins/ffi-words.cpp.obj
C:\PROGRA~1\MICROS~1\2022\COMMUN~1\VC\Tools\MSVC\1444~1.352\bin\Hostx86\x86\cl.exe  /nologo /TP -DSORTH_EXPORT=1 -DSORTH_LLVM_FOUND=0 -DSORTH_VERSION=\"dev-f0e2f4e0-2025.01.17\" -Dsorth_interpreter_EXPORTS -IC:\w\f\rsorth\sorth\src -external:IC:\w\f\rsorth\sorth\build\vcpkg_installed\x86-windows\include -external:W0 /DWIN32 /D_WINDOWS /GR /EHsc /Zi /Ob0 /Od /RTC1 -std:c++20 -MDd "-DSORTH_COMPILER=\"cl 19.44.35207.1\"" /YuC:/w/f/rsorth/sorth/build/CMakeFiles/sorth-interpreter.dir/cmake_pch.hxx /FpC:/w/f/rsorth/sorth/build/CMakeFiles/sorth-interpreter.dir/./cmake_pch.cxx.pch /FIC:/w/f/rsorth/sorth/build/CMakeFiles/sorth-interpreter.dir/cmake_pch.hxx /showIncludes /FoCMakeFiles\sorth-interpreter.dir\src\run-time\built-ins\ffi-words.cpp.obj /FdCMakeFiles\sorth-interpreter.dir\ /FS -c C:\w\f\rsorth\sorth\src\run-time\built-ins\ffi-words.cpp   
C:\w\f\rsorth\sorth\src\run-time\built-ins\ffi-words.cpp(787): error C3861: 'throw_windows_error': identifier not found
C:\w\f\rsorth\sorth\src\run-time\built-ins\ffi-words.cpp(832): error C3861: 'throw_windows_error': identifier not found
[39/42] Building CXX object CMakeFiles\sorth-interpreter.dir\src\run-time\data-structures\value.cpp.obj
ninja: build stopped: subcommand failed.
```


I did not have success with the windows build without some modification.  It is working with these changes.